### PR TITLE
C1- Lock registered adapter/l1token

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,5 +1,5 @@
 bracketSpacing: true
-printWidth: 120
+printWidth: 121
 proseWrap: "always"
 singleQuote: false
 tabWidth: 2

--- a/.solhint.json
+++ b/.solhint.json
@@ -5,7 +5,7 @@
     "compiler-version": ["error", ">=0.8.25"],
     "func-name-mixedcase": "off",
     "func-visibility": ["error", { "ignoreConstructors": true }],
-    "max-line-length": ["error", 120],
+    "max-line-length": ["error", 121],
     "named-parameters-mapping": "warn",
     "no-console": "off",
     "not-rely-on-time": "off",

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ order for Renzo to enable bridging the ezETH token it would need to:
 
 ## An XERC20 token on Ethereum with a XERC20 counterpart token on Arbitrum
 
-There are a few prerequisites to keep in mind for registering a token in the router associating it to a specific
-gateway.
+There are a few prerequisites to keep in mind for registering a token in the router associating it to a specific gateway.
 
 First of all, the L1 counterpart of the token must conform to the ICustomToken interface. This means that:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,8 +27,8 @@ Notice that the values used for `GATEWAY_SALT` can be used only once on each net
 
 **L1XERC20Gateway** Required environment variables:
 
-- `GATEWAY_SALT`: Salt used for deploying the contract through `CREATE3Factory`. **IMPORTANT:** make sure to use the
-  same address for `L2XERC20Gateway`
+- `GATEWAY_SALT`: Salt used for deploying the contract through `CREATE3Factory`. **IMPORTANT:** make sure to use the same
+  address for `L2XERC20Gateway`
 - `DEPLOYER_PK`: Your deployer address private key. **IMPORTANT:** make sure to use the same address for
   `L2XERC20Gateway`
 - `CREATE3_FACTORY`: Address of the `CREATE3Factory`. **IMPORTANT:** make sure to use the same address for
@@ -52,8 +52,8 @@ $ yarn deploy:gateway
 
 **L2XER20Gateway** Required environment variables:
 
-- `GATEWAY_SALT`: Salt used for deploying the contract through `CREATE3Factory`. **IMPORTANT:** make sure to use the
-  same address for `L1XERC20Gateway`
+- `GATEWAY_SALT`: Salt used for deploying the contract through `CREATE3Factory`. **IMPORTANT:** make sure to use the same
+  address for `L1XERC20Gateway`
 - `DEPLOYER_PK`: Your deployer address private key. **IMPORTANT:** make sure to use the same address for
   `L1XERC20Gateway`
 - `CREATE3_FACTORY`: Address of the `CREATE3Factory`. **IMPORTANT:** make sure to use the same address for
@@ -82,8 +82,8 @@ Notice that the values used for `GATEWAY_SALT` can be used only once on each net
 
 **L1LockboxGateway** Required environment variables:
 
-- `GATEWAY_SALT`: Salt used for deploying the contract through `CREATE3Factory`. **IMPORTANT:** make sure to use the
-  same address for `L2XERC20Gateway`
+- `GATEWAY_SALT`: Salt used for deploying the contract through `CREATE3Factory`. **IMPORTANT:** make sure to use the same
+  address for `L2XERC20Gateway`
 - `DEPLOYER_PK`: Your deployer address private key. **IMPORTANT:** make sure to use the same address for
   `L2XERC20Gateway`
 - `CREATE3_FACTORY`: Address of the `CREATE3Factory`. **IMPORTANT:** make sure to use the same address for
@@ -108,8 +108,8 @@ $ yarn deploy:lockboxGateway
 
 **L2LockboxGateway** Required environment variables:
 
-- `GATEWAY_SALT`: Salt used for deploying the contract through `CREATE3Factory`. **IMPORTANT:** make sure to use the
-  same address for `L1XERC20Gateway`
+- `GATEWAY_SALT`: Salt used for deploying the contract through `CREATE3Factory`. **IMPORTANT:** make sure to use the same
+  address for `L1XERC20Gateway`
 - `DEPLOYER_PK`: Your deployer address private key. **IMPORTANT:** make sure to use the same address for
   `L1XERC20Gateway`
 - `CREATE3_FACTORY`: Address of the `CREATE3Factory`. **IMPORTANT:** make sure to use the same address for
@@ -135,8 +135,8 @@ $ yarn deploy:lockboxGateway:arb
 
 **XERC20**
 
-The XERC20 token is deployed using a `XERC20Factory` contract. In order to have the token deployed on the same address
-on both networks you must to use the same `DEPLOYER_PK`, `XERC20_FACTORY`, `XERC20_NAME` and `XERC20_SYMBOL` values for
+The XERC20 token is deployed using a `XERC20Factory` contract. In order to have the token deployed on the same address on
+both networks you must to use the same `DEPLOYER_PK`, `XERC20_FACTORY`, `XERC20_NAME` and `XERC20_SYMBOL` values for
 running bot scripts.
 
 Required environment variables:

--- a/foundry.toml
+++ b/foundry.toml
@@ -29,7 +29,7 @@
 [fmt]
   bracket_spacing = true
   int_types = "long"
-  line_length = 120
+  line_length = 121
   multiline_func_header = "all"
   number_underscore = "thousands"
   quote_style = "double"

--- a/src/L1LockboxGateway.sol
+++ b/src/L1LockboxGateway.sol
@@ -90,18 +90,7 @@ contract L1LockboxGateway is XERC20BaseGateway, L1CustomGateway {
     /**
      * @dev Not implemented since L1/L2 token relation is being built upon deployment.
      */
-    function registerTokenToL2(
-        address,
-        uint256,
-        uint256,
-        uint256
-    )
-        external
-        payable
-        virtual
-        override
-        returns (uint256)
-    {
+    function registerTokenToL2(address, uint256, uint256, uint256) external payable virtual override returns (uint256) {
         revert NotImplementedFunction();
     }
 

--- a/src/L1XERC20Gateway.sol
+++ b/src/L1XERC20Gateway.sol
@@ -72,14 +72,7 @@ contract L1XERC20Gateway is XERC20BaseGateway, L1CustomGateway {
         l1RegisteredTokens[_l1Token] = true;
         l2RegisteredTokens[_l2Address] = true;
 
-        return _registerTokenToL2(
-            _l2Address,
-            _maxGas,
-            _gasPriceBid,
-            _maxSubmissionCost,
-            _creditBackAddress,
-            msg.value
-        );
+        return _registerTokenToL2(_l2Address, _maxGas, _gasPriceBid, _maxSubmissionCost, _creditBackAddress, msg.value);
     }
 
     /**
@@ -93,11 +86,18 @@ contract L1XERC20Gateway is XERC20BaseGateway, L1CustomGateway {
         uint256 _maxGas,
         uint256 _gasPriceBid,
         uint256 _maxSubmissionCost
-    ) external payable virtual override onlyOwner returns (uint256) {
+    )
+        external
+        payable
+        virtual
+        override
+        onlyOwner
+        returns (uint256)
+    {
         if (_l1Addresses.length != _l2Addresses.length) revert InvalidLengths();
 
         address _l1Token;
-        for (uint i = 0; i < _l1Addresses.length; i++) {
+        for (uint256 i = 0; i < _l1Addresses.length; i++) {
             _l1Token = _l1Addresses[i];
 
             if (addressIsAdapter(_l1Addresses[i])) {
@@ -109,15 +109,7 @@ contract L1XERC20Gateway is XERC20BaseGateway, L1CustomGateway {
             l2RegisteredTokens[_l2Addresses[i]] = true;
         }
 
-        return
-            _forceRegisterTokenToL2(
-                _l1Addresses,
-                _l2Addresses,
-                _maxGas,
-                _gasPriceBid,
-                _maxSubmissionCost,
-                msg.value
-            );
+        return _forceRegisterTokenToL2(_l1Addresses, _l2Addresses, _maxGas, _gasPriceBid, _maxSubmissionCost, msg.value);
     }
 
     /**

--- a/src/L1XERC20Gateway.sol
+++ b/src/L1XERC20Gateway.sol
@@ -22,11 +22,14 @@ contract L1XERC20Gateway is XERC20BaseGateway, L1CustomGateway {
     using ERC165Checker for address;
 
     // stores addresses of registered tokens
+    mapping(address => address) public adapterToToken;
     mapping(address => bool) public l1RegisteredTokens;
     mapping(address => bool) public l2RegisteredTokens;
 
     error AlreadyRegisteredL1Token();
     error AlreadyRegisteredL2Token();
+    error InvalidLengths();
+    error NotRegisteredToken();
 
     /**
      * @dev Sets the arbitrum router, inbox and the owner of this contract.
@@ -56,19 +59,65 @@ contract L1XERC20Gateway is XERC20BaseGateway, L1CustomGateway {
         override
         returns (uint256)
     {
-        address _token = msg.sender;
+        address _l1Token = msg.sender;
 
         if (addressIsAdapter(msg.sender)) {
-            _token = IXERC20Adapter(_token).getXERC20();
+            _l1Token = IXERC20Adapter(_l1Token).getXERC20();
         }
 
-        if (l1RegisteredTokens[_token]) revert AlreadyRegisteredL1Token();
+        if (l1RegisteredTokens[_l1Token]) revert AlreadyRegisteredL1Token();
         if (l2RegisteredTokens[_l2Address]) revert AlreadyRegisteredL2Token();
 
-        l1RegisteredTokens[_token] = true;
+        adapterToToken[msg.sender] = _l1Token;
+        l1RegisteredTokens[_l1Token] = true;
         l2RegisteredTokens[_l2Address] = true;
 
-        return _registerTokenToL2(_l2Address, _maxGas, _gasPriceBid, _maxSubmissionCost, _creditBackAddress, msg.value);
+        return _registerTokenToL2(
+            _l2Address,
+            _maxGas,
+            _gasPriceBid,
+            _maxSubmissionCost,
+            _creditBackAddress,
+            msg.value
+        );
+    }
+
+    /**
+     * @notice Override L1CustomGateway function setting l1RegisteredTokens and l2RegisteredTokens.
+     * It assumes the owner checked both addresses offchain before force registering. Multi-sig or governance is
+     * recommended be used as the owner
+     */
+    function forceRegisterTokenToL2(
+        address[] calldata _l1Addresses,
+        address[] calldata _l2Addresses,
+        uint256 _maxGas,
+        uint256 _gasPriceBid,
+        uint256 _maxSubmissionCost
+    ) external payable virtual override onlyOwner returns (uint256) {
+        if (_l1Addresses.length != _l2Addresses.length) revert InvalidLengths();
+
+        address _l1Token;
+        for (uint i = 0; i < _l1Addresses.length; i++) {
+            _l1Token = _l1Addresses[i];
+
+            if (addressIsAdapter(_l1Addresses[i])) {
+                _l1Token = IXERC20Adapter(_l1Token).getXERC20();
+            }
+
+            adapterToToken[_l1Addresses[i]] = _l1Token;
+            l1RegisteredTokens[_l1Token] = true;
+            l2RegisteredTokens[_l2Addresses[i]] = true;
+        }
+
+        return
+            _forceRegisterTokenToL2(
+                _l1Addresses,
+                _l2Addresses,
+                _maxGas,
+                _gasPriceBid,
+                _maxSubmissionCost,
+                msg.value
+            );
     }
 
     /**
@@ -88,11 +137,9 @@ contract L1XERC20Gateway is XERC20BaseGateway, L1CustomGateway {
         override
         returns (uint256 amountReceived)
     {
-        address _token = _l1TokenOrAdapter;
+        address _token = adapterToToken[_l1TokenOrAdapter];
 
-        if (addressIsAdapter(_l1TokenOrAdapter)) {
-            _token = IXERC20Adapter(_l1TokenOrAdapter).getXERC20();
-        }
+        if (_token == address(0)) revert NotRegisteredToken();
 
         return _outboundEscrowTransfer(_token, _from, _amount);
     }
@@ -105,11 +152,9 @@ contract L1XERC20Gateway is XERC20BaseGateway, L1CustomGateway {
      * @param _amount Amount of tokens
      */
     function inboundEscrowTransfer(address _l1TokenOrAdapter, address _dest, uint256 _amount) internal override {
-        address _token = _l1TokenOrAdapter;
+        address _token = adapterToToken[_l1TokenOrAdapter];
 
-        if (addressIsAdapter(_l1TokenOrAdapter)) {
-            _token = IXERC20Adapter(_l1TokenOrAdapter).getXERC20();
-        }
+        if (_token == address(0)) revert NotRegisteredToken();
 
         _inboundEscrowTransfer(_token, _dest, _amount);
     }

--- a/test/L1XERC20Gateway.t.sol
+++ b/test/L1XERC20Gateway.t.sol
@@ -4,10 +4,15 @@ pragma solidity >=0.8.25 <0.9.0;
 // solhint-disable-next-line
 import { console2 } from "forge-std/console2.sol";
 
+import { XERC20 } from "xerc20/contracts/XERC20.sol";
 import { IInbox } from "@arbitrum/nitro-contracts/src/bridge/IInbox.sol";
 import { InboxMock } from "@arbitrum/tokenbridge/test/InboxMock.sol";
+import { L2CustomGateway } from "@arbitrum/tokenbridge/arbitrum/gateway/L2CustomGateway.sol";
 
 import { L1XERC20BaseGatewayTest } from "test/L1XERC20BaseGatewayTest.t.sol";
+import { L1XERC20Gateway } from "src/L1XERC20Gateway.sol";
+
+import {AttackerAdapter} from "test/mocks/AttackerAdapter.sol";
 
 contract L1XERC20GatewayTest is L1XERC20BaseGatewayTest {
     function setUp() public override {
@@ -17,12 +22,66 @@ contract L1XERC20GatewayTest is L1XERC20BaseGatewayTest {
         super.setUp();
     }
 
+    function registerAdapter(address _adapter) internal {
+        address[] memory l1Addresses = new address[](1);
+        l1Addresses[0] = address(_adapter);
+        address[] memory l2Addresses = new address[](1);
+        l2Addresses[0] = makeAddr("l2Token");
+
+        deal(_owner, 2);
+
+        vm.prank(_owner);
+        l1Gateway.forceRegisterTokenToL2{ value: 2 }(l1Addresses, l2Addresses, 1, 1, 1);
+
+    }
+
     function test_AddressIsAdapter() public view {
         assertEq(l1Gateway.addressIsAdapter(address(xerc20)), false);
         assertEq(l1Gateway.addressIsAdapter(address(adapter)), true);
     }
 
+    function test_forceRegisterTokenToL2_onlyOwner() public {
+        address[] memory l1Addresses = new address[](1);
+        l1Addresses[0] = address(adapter);
+        address[] memory l2Addresses = new address[](1);
+        l2Addresses[0] = makeAddr("l2Token");
+
+        address nonOwner = makeAddr("non_owner");
+        deal(nonOwner, 2);
+
+        vm.prank(nonOwner);
+        vm.expectRevert("ONLY_OWNER");
+        l1Gateway.forceRegisterTokenToL2{ value: 2 }(l1Addresses, l2Addresses, 1, 1, 1);
+    }
+    function test_forceRegisterTokenToL2() public {
+        address[] memory l1Addresses = new address[](1);
+        l1Addresses[0] = address(adapter);
+        address[] memory l2Addresses = new address[](1);
+        l2Addresses[0] = makeAddr("l2Token");
+
+        bytes memory _data = abi.encodeWithSelector(
+            L2CustomGateway.registerTokenFromL1.selector,
+            l1Addresses,
+            l2Addresses
+        );
+
+        vm.expectEmit(true, true, true, true, l1Inbox);
+        emit InboxRetryableTicket(
+            address(l1Gateway),
+            address(l1Gateway.counterpartGateway()),
+            0,
+            1,
+            _data
+        );
+
+        deal(_owner, 2);
+        vm.prank(_owner);
+        l1Gateway.forceRegisterTokenToL2{ value: 2 }(l1Addresses, l2Addresses, 1, 1, 1);
+    }
+
     function test_FinalizeInboundTransfer() public {
+        registerAdapter(address(adapter));
+
         InboxMock(address(l1Inbox)).setL2ToL1Sender(l1Gateway.counterpartGateway());
 
         uint256 exitNum = 7;
@@ -43,10 +102,59 @@ contract L1XERC20GatewayTest is L1XERC20BaseGatewayTest {
         assertEq(xerc20.balanceOf(_dest), balanceBefore + amountToBridge);
     }
 
+    function test_inboundEscrowTransfer_NotRegisteredToken() public {
+        InboxMock(address(l1Inbox)).setL2ToL1Sender(l1Gateway.counterpartGateway());
+
+        uint256 exitNum = 7;
+        bytes memory callHookData = "";
+        bytes memory data = abi.encode(exitNum, callHookData);
+
+        vm.prank(address(IInbox(l1Gateway.inbox()).bridge()));
+        vm.expectRevert(L1XERC20Gateway.NotRegisteredToken.selector);
+        l1Gateway.finalizeInboundTransfer(address(adapter), _user, _dest, amountToBridge, data);
+    }
+    function test_inboundEscrowTransfer_uses_registered_adapterToToken() public {
+        address attacker = makeAddr("attacker");
+        XERC20 fakeXerc20 = new XERC20("FAKE", "FAKE", attacker);
+
+        vm.prank(attacker);
+        fakeXerc20.setLimits(address(l1Gateway), 420 ether, 69 ether);
+
+        AttackerAdapter attackerAdapter = new AttackerAdapter(address(fakeXerc20), address(l1Gateway), attacker);
+
+        registerAdapter(address(attackerAdapter));
+
+        vm.prank(attacker);
+        attackerAdapter.setXERC20(address(xerc20));
+
+        InboxMock(address(l1Inbox)).setL2ToL1Sender(l1Gateway.counterpartGateway());
+
+        uint256 exitNum = 7;
+        bytes memory callHookData = "";
+        bytes memory data = abi.encode(exitNum, callHookData);
+
+        vm.expectEmit(true, true, true, true, address(fakeXerc20));
+        emit Transfer(address(0), attacker, amountToBridge);
+
+        vm.expectEmit(true, true, true, true, address(l1Gateway));
+        emit WithdrawalFinalized(address(attackerAdapter), attacker, attacker, exitNum, amountToBridge);
+
+        uint256 balanceBefore = xerc20.balanceOf(attacker);
+        uint256 balanceFakeBefore = fakeXerc20.balanceOf(attacker);
+
+        vm.prank(address(IInbox(l1Gateway.inbox()).bridge()));
+        l1Gateway.finalizeInboundTransfer(address(attackerAdapter), attacker, attacker, amountToBridge, data);
+
+        assertEq(fakeXerc20.balanceOf(attacker), balanceFakeBefore + amountToBridge);
+        assertEq(xerc20.balanceOf(attacker), balanceBefore);
+    }
+
     ////
     // Event declarations for assertions
     ////
     event WithdrawalFinalized(
         address l1Token, address indexed _from, address indexed _to, uint256 indexed _exitNum, uint256 _amount
     );
+
+    event InboxRetryableTicket(address from, address to, uint256 value, uint256 maxGas, bytes data);
 }

--- a/test/L1XERC20Gateway.t.sol
+++ b/test/L1XERC20Gateway.t.sol
@@ -12,7 +12,7 @@ import { L2CustomGateway } from "@arbitrum/tokenbridge/arbitrum/gateway/L2Custom
 import { L1XERC20BaseGatewayTest } from "test/L1XERC20BaseGatewayTest.t.sol";
 import { L1XERC20Gateway } from "src/L1XERC20Gateway.sol";
 
-import {AttackerAdapter} from "test/mocks/AttackerAdapter.sol";
+import { AttackerAdapter } from "test/mocks/AttackerAdapter.sol";
 
 contract L1XERC20GatewayTest is L1XERC20BaseGatewayTest {
     function setUp() public override {
@@ -32,7 +32,6 @@ contract L1XERC20GatewayTest is L1XERC20BaseGatewayTest {
 
         vm.prank(_owner);
         l1Gateway.forceRegisterTokenToL2{ value: 2 }(l1Addresses, l2Addresses, 1, 1, 1);
-
     }
 
     function test_AddressIsAdapter() public view {
@@ -53,26 +52,18 @@ contract L1XERC20GatewayTest is L1XERC20BaseGatewayTest {
         vm.expectRevert("ONLY_OWNER");
         l1Gateway.forceRegisterTokenToL2{ value: 2 }(l1Addresses, l2Addresses, 1, 1, 1);
     }
+
     function test_forceRegisterTokenToL2() public {
         address[] memory l1Addresses = new address[](1);
         l1Addresses[0] = address(adapter);
         address[] memory l2Addresses = new address[](1);
         l2Addresses[0] = makeAddr("l2Token");
 
-        bytes memory _data = abi.encodeWithSelector(
-            L2CustomGateway.registerTokenFromL1.selector,
-            l1Addresses,
-            l2Addresses
-        );
+        bytes memory _data =
+            abi.encodeWithSelector(L2CustomGateway.registerTokenFromL1.selector, l1Addresses, l2Addresses);
 
         vm.expectEmit(true, true, true, true, l1Inbox);
-        emit InboxRetryableTicket(
-            address(l1Gateway),
-            address(l1Gateway.counterpartGateway()),
-            0,
-            1,
-            _data
-        );
+        emit InboxRetryableTicket(address(l1Gateway), address(l1Gateway.counterpartGateway()), 0, 1, _data);
 
         deal(_owner, 2);
         vm.prank(_owner);
@@ -113,6 +104,7 @@ contract L1XERC20GatewayTest is L1XERC20BaseGatewayTest {
         vm.expectRevert(L1XERC20Gateway.NotRegisteredToken.selector);
         l1Gateway.finalizeInboundTransfer(address(adapter), _user, _dest, amountToBridge, data);
     }
+
     function test_inboundEscrowTransfer_uses_registered_adapterToToken() public {
         address attacker = makeAddr("attacker");
         XERC20 fakeXerc20 = new XERC20("FAKE", "FAKE", attacker);

--- a/test/forking/L1XERC20Gateway.t.sol
+++ b/test/forking/L1XERC20Gateway.t.sol
@@ -12,7 +12,7 @@ import { L1XERC20Adapter } from "src/L1XERC20Adapter.sol";
 import { L1XERC20Gateway } from "src/L1XERC20Gateway.sol";
 
 import { L1XERC20BaseGatewayTest } from "test/L1XERC20BaseGatewayTest.t.sol";
-import {AttackerAdapter} from "test/mocks/AttackerAdapter.sol";
+import { AttackerAdapter } from "test/mocks/AttackerAdapter.sol";
 
 contract L1XERC20GatewayForkingTest is L1XERC20BaseGatewayTest {
     uint256 internal mainnetFork;
@@ -156,7 +156,13 @@ contract L1XERC20GatewayForkingTest is L1XERC20BaseGatewayTest {
         deal(attacker, 10 ether);
         vm.prank(attacker);
         router.outboundTransferCustomRefund{ value: 3 ether }(
-            address(attackerAdapter), attacker, _attacker, amountToBridge, maxGas, gasPriceBid, abi.encode(maxSubmissionCost, "")
+            address(attackerAdapter),
+            attacker,
+            _attacker,
+            amountToBridge,
+            maxGas,
+            gasPriceBid,
+            abi.encode(maxSubmissionCost, "")
         );
 
         assertEq(fakeXerc20.balanceOf(attacker), balanceFakeBefore - amountToBridge);

--- a/test/mocks/AttackerAdapter.sol
+++ b/test/mocks/AttackerAdapter.sol
@@ -2,8 +2,6 @@
 pragma solidity >=0.8.25 <0.9.0;
 
 import { L1XERC20Adapter } from "src/L1XERC20Adapter.sol";
-import { IL1CustomGateway } from "src/interfaces/IL1CustomGateway.sol";
-import { IL1GatewayRouter } from "src/interfaces/IL1GatewayRouter.sol";
 
 contract AttackerAdapter is L1XERC20Adapter {
     constructor(

--- a/test/mocks/AttackerAdapter.sol
+++ b/test/mocks/AttackerAdapter.sol
@@ -10,7 +10,9 @@ contract AttackerAdapter is L1XERC20Adapter {
         address _xerc20,
         address _gatewayAddress,
         address _owner
-    ) L1XERC20Adapter(_xerc20, _gatewayAddress, _owner) {}
+    )
+        L1XERC20Adapter(_xerc20, _gatewayAddress, _owner)
+    { }
 
     function setXERC20(address _xer20) public {
         xerc20 = _xer20;

--- a/test/mocks/AttackerAdapter.sol
+++ b/test/mocks/AttackerAdapter.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.25 <0.9.0;
+
+import { L1XERC20Adapter } from "src/L1XERC20Adapter.sol";
+import { IL1CustomGateway } from "src/interfaces/IL1CustomGateway.sol";
+import { IL1GatewayRouter } from "src/interfaces/IL1GatewayRouter.sol";
+
+contract AttackerAdapter is L1XERC20Adapter {
+    constructor(
+        address _xerc20,
+        address _gatewayAddress,
+        address _owner
+    ) L1XERC20Adapter(_xerc20, _gatewayAddress, _owner) {}
+
+    function setXERC20(address _xer20) public {
+        xerc20 = _xer20;
+    }
+}


### PR DESCRIPTION
Lock the registered addresses in order to prevent an attacker to change the underlying XERC20 of an Adapter after registering or faking a not adapter and then upgrading to an adapter with a underlying XERC20.